### PR TITLE
Security updates for DockerExec

### DIFF
--- a/DockerExec
+++ b/DockerExec
@@ -763,13 +763,16 @@ elif [[ "do" == "$ENVIRONMENT" ]]; then
 
     # shortcut to list all docker containers
     elif [[ "self-update" == "$ACTION" ]]; then
-        if [[ ! -d "$PROXY_PATH/.git" ]]; then
+        SCRIPT_PATH=`realpath "$0"`
+        BASE_DIR=`dirname "$SCRIPT_PATH"`
+
+        if [[ ! -d "$BASE_DIR/.git" ]]; then
             print_error "No .git directory was found in proxy directory. Did you clone or download?"
             print_error "If you downloaded this project, this command will not work. Please download the current archive." 1
             exit 1
         fi
 
-        cd "$PROXY_PATH"
+        cd "$BASE_DIR"
         git fetch --tags
 
         LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)

--- a/DockerExec
+++ b/DockerExec
@@ -162,6 +162,10 @@ command -v docker-compose > /dev/null 2>&1 || {
     exit 1
 }
 
+# add environment variables for docker
+export COMPOSE_DOCKER_CLI_BUILD=0
+export DOCKER_BUILDKIT=0
+
 # remove the trailing slash
 PROXY_PATH=${PROXY_PATH%/}
 

--- a/DockerExec
+++ b/DockerExec
@@ -171,6 +171,7 @@ PROXY_PATH=${PROXY_PATH%/}
 
 # set some more defaults
 ENV_FILE=".env"
+PROXY_ENV_FILE="$PROXY_PATH/$ENV_FILE"
 CURRENT_DIR=`pwd`
 LINUX_HOSTS=/etc/hosts
 CERTS_PATH="$PROXY_PATH/certs"
@@ -523,7 +524,7 @@ elif [[ "proxy" == "$ENVIRONMENT" ]]; then
 
     # start the docker proxy db with bash
     elif [[ "db" == "$ACTION" ]]; then
-        DB_NAME=`grep "^DB_NAME=" "$ENV_FILE" | sed -e 's/^DB_NAME=//' | sed -e 's/[[:space:]]*$//'`
+        DB_NAME=`grep "^DB_NAME=" "$PROXY_ENV_FILE" | sed -e 's/^DB_NAME=//' | sed -e 's/[[:space:]]*$//'`
         RUNNING_APP=`docker ps -aq -f name="$DB_NAME" -f status="running"`
 
         if [[ ! -z "$RUNNING_APP" ]]; then
@@ -544,7 +545,7 @@ elif [[ "proxy" == "$ENVIRONMENT" ]]; then
 
     # start the docker proxy pg with bash
     elif [[ "pg" == "$ACTION" ]]; then
-        PG_NAME=`grep "^PG_NAME=" "$ENV_FILE" | sed -e 's/^PG_NAME=//' | sed -e 's/[[:space:]]*$//'`
+        PG_NAME=`grep "^PG_NAME=" "$PROXY_ENV_FILE" | sed -e 's/^PG_NAME=//' | sed -e 's/[[:space:]]*$//'`
         RUNNING_APP=`docker ps -aq -f name="$PG_NAME" -f status="running"`
 
         if [[ ! -z "$RUNNING_APP" ]]; then

--- a/readme.md
+++ b/readme.md
@@ -324,3 +324,8 @@ Although the Docker-Proxy-Stack is fully functional, there is a lot of potential
   - add common tasks
   - rewrite in Python
   - make functionality more discoverable
+- Windows
+  - make it all work on Windows
+  - use correct Docker Socket path
+  - make generating SSL certs work (use correct SSL cert path)
+  - make writing to /etc/hosts work


### PR DESCRIPTION
- disabled the buildkit extension for `docker` (for now)
- split `.env` file usage into the file within `$PROXY_PATH` and the one in current directory
   + this fixes a bug when trying to import a .sql file from command line
- fixed the `DockerExec self-update` command, when the proxy path does not match the `DockerExec` path
- updated ToDos for Windows operating system